### PR TITLE
v2: Rust CLI, credits payment, delegated deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 A GitHub action that deploys a website or dApp frontend on Aleph Cloud.
 For more information about Web3 Hosting with Aleph, check [the documentation](https://docs.aleph.cloud/devhub/deploying-and-hosting/web-hosting/#web3-hosting-on-aleph-cloud).
 
+Deployments are paid with [Aleph Cloud credits](https://docs.aleph.cloud/devhub/sdks-and-tools/aleph-cli/commands/credits.html) held by the wallet that owns the website. Each deployment registers a new version of your website on your Aleph account, and automatically re-points the domains attached to it.
+
 ## Usage
 
 ### Classic usage
@@ -31,30 +33,47 @@ jobs:
       - run: npm build
 
       - name: Deploy on Aleph
-        uses: aleph-im/web3-hosting-action@v1.1.4
+        uses: aleph-im/web3-hosting-action@v2
         with:
           path: 'out'
           private-key: ${{ secrets.ALEPH_PRIVATE_KEY }}
           domain: your-website.com
 ```
 
-### Deploy without a domain
+The wallet of `private-key` must hold credits, which can be bought with the [Aleph CLI](https://docs.aleph.cloud/devhub/sdks-and-tools/aleph-cli/) (`aleph credit buy`) or from the Aleph Cloud console.\
+The website is identified by `website-name` (defaults to the repository name).
 
-If you don't need a domain name, don't pass anything to the corresponding parameter.\
-A domain in the format `https://{ipfs-cid-v1}.ipfs.aleph.sh` will be allocated automatically.
+### Delegated deployments (recommended)
+
+Instead of giving CI a wallet that holds funds, use a single **owner wallet** that holds the credits and owns all your websites, and a low-privilege **CI wallet** per repository that only signs deployments on its behalf. If a CI key leaks, revoke its authorization and nothing else is at risk: the scoped grant below can't touch the owner's funds, instances or other messages.
+
+One-time setup with the [Aleph CLI](https://docs.aleph.cloud/devhub/sdks-and-tools/aleph-cli/), signing as the **owner** wallet:
+
+```sh
+aleph authorization add <ci-wallet-address> \
+  --message-types store,aggregate \
+  --aggregate-keys websites,domains \
+  --channels ALEPH-CLOUDSOLUTIONS
+```
+
+Then put the CI wallet's private key in your repository secrets and pass the owner's address to the action:
 
 ```yml
 - name: Deploy on Aleph
-  uses: aleph-im/web3-hosting-action@v1.1.4
+  uses: aleph-im/web3-hosting-action@v2
   with:
     path: 'out'
-    private-key: ${{ secrets.ALEPH_PRIVATE_KEY }}
+    private-key: ${{ secrets.ALEPH_CI_PRIVATE_KEY }}
+    owner-address: '0xYourOwnerWalletAddress'
+    domain: your-website.com
 ```
+
+The website and its domains are owned by the owner wallet, and credits are consumed from it. The action fails early with a clear error if the authorization is missing or the owner has no credits.
 
 ### Deploy previews
 
-Deploy previews on your PRs, completely free without any authentication required.\
-A comment will be added to the PR with the link to access the preview.
+On `pull_request` events, the action always deploys a free preview: no authentication required, no credits consumed, and a comment is added to the PR with the link to access it.\
+Previews are garbage-collected ~24 hours after upload (re-run the job to refresh the link), and never touch your domain or website versions.
 
 ```yml
 on:
@@ -76,25 +95,21 @@ jobs:
       - run: npm build
 
       - name: Deploy on Aleph
-        uses: aleph-im/web3-hosting-action@v1.1.4
+        uses: aleph-im/web3-hosting-action@v2
         with:
           path: 'out'
 ```
 
 > Don't forget the `pull-requests: write` permission, or the comment won't be posted on the PR.
 
-> 💡 Previews will be garbage-collected after some time, for production usage please pass the private key of a wallet holding a sufficient amount of ALEPH tokens.
+### Remove older versions
 
-### Remove older files
-
-Deploying a new version of your site will change the IPFS file your domain points to, but won't delete the files of older versions.\
-You can use the `retention_days` parameter to automatically delete all the Aleph files in your account that are older than this number of days.
-
-> ⚠️ Use this only if you are using this Aleph account only for deploying this website (which is recommended for security reasons), or this could remove files that you uploaded with the same wallet for other purposes.
+Each deployment creates a new version of your website, and previous versions stay stored on Aleph, where storage is billed in credits over time.\
+Use the `retention_days` parameter to automatically delete the previous versions of this website that are older than this number of days. Only the previous versions of this website are ever touched, never the other files of the account.
 
 ```yml
 - name: Deploy on Aleph
-  uses: aleph-im/web3-hosting-action@v1.1.4
+  uses: aleph-im/web3-hosting-action@v2
   with:
     path: 'out'
     private-key: ${{ secrets.ALEPH_PRIVATE_KEY }}
@@ -102,32 +117,48 @@ You can use the `retention_days` parameter to automatically delete all the Aleph
     retention_days: 30
 ```
 
+### Custom domain DNS records
+
+When linking a domain for the first time, configure the following DNS records (the action also prints them in its logs):
+
+| Type  | Name                        | Value                                              |
+| ----- | --------------------------- | -------------------------------------------------- |
+| CNAME | `your-website.com`          | `ipfs.public.aleph.sh`                             |
+| CNAME | `_dnslink.your-website.com` | `_dnslink.your-website.com.static.public.aleph.sh` |
+| TXT   | `_control.your-website.com` | The owner wallet address                           |
+
+> The TXT record must contain the address that **owns** the website: `owner-address` when using delegated deployments, the `private-key` wallet's address otherwise.
+
 ## Inputs
 
 ### Action inputs
 
-| Name             | Description                                                               | Required | Default |
-| ---------------- | ------------------------------------------------------------------------- | -------- | ------- |
-| `path`           | Path to the static website's files (eg frontend/out)                      | ✅        |         |
-| `private-key`    | The private key of the Ethereum wallet to use to connect to Aleph         |          |         |
-| `domain`         | Domain name to link to the deployed site (eg libertai.io)                 |          |         |
-| `retention_days` | Delete files older than this number of days. Leave blank to skip deletion |          |         |
+| Name             | Description                                                                                       | Required | Default         |
+| ---------------- | ------------------------------------------------------------------------------------------------- | -------- | --------------- |
+| `path`           | Path to the static website's files (eg frontend/out)                                              | ✅        |                 |
+| `private-key`    | The private key of the Ethereum wallet used to sign the deployment                                |          |                 |
+| `owner-address`  | Address of the wallet that owns the website and pays with its credits (delegated deployments)     |          |                 |
+| `website-name`   | Identifier of the website on your Aleph account                                                   |          | Repository name |
+| `domain`         | Domain name to link to the deployed site (eg libertai.io)                                         |          |                 |
+| `retention_days` | Delete previous versions of this website older than this number of days. Leave blank to keep all  |          |                 |
 
 ## Outputs
 
 ### Action outputs
 
-You can get the following outputs from this actions:
+You can get the following outputs from this action:
 
-| Name  | Description                            |
-| ----- | -------------------------------------- |
-| `url` | The deployed URL to access the website |
+| Name      | Description                                            |
+| --------- | ------------------------------------------------------ |
+| `url`     | The deployed URL to access the website                 |
+| `cid`     | The IPFS CID (v1) of the deployed files                |
+| `version` | The version of the website on Aleph (empty for previews) |
 
 ### Example output
 
 ```yml
 - name: Deploy on Aleph
-  uses: aleph-im/web3-hosting-action@v1.1.4
+  uses: aleph-im/web3-hosting-action@v2
   id: deploy
   with:
     path: 'out'
@@ -136,4 +167,15 @@ You can get the following outputs from this actions:
 - name: Check outputs
   run: |
     echo "url: ${{ steps.deploy.outputs.url }}"
+    echo "cid: ${{ steps.deploy.outputs.cid }}"
+    echo "version: ${{ steps.deploy.outputs.version }}"
 ```
+
+## Migrating from v1
+
+- The same `private-key` secret works unchanged (raw hex private key).
+- Payment switched from holding ALEPH tokens to [credits](https://docs.aleph.cloud/devhub/sdks-and-tools/aleph-cli/commands/credits.html): the owning wallet must hold credits or the deployed content is garbage-collected.
+- Websites are now registered on your Aleph account with a name and version history, instead of being a bare IPFS pin.
+- `pull_request` events now always deploy a free ephemeral preview, even if a private key is passed: production deployments only happen on other events (push, workflow_dispatch...).
+- `retention_days` now only deletes the previous versions of this website, instead of all the files of the account older than the threshold.
+- New `owner-address` input for delegated deployments with a single owner wallet and low-privilege CI keys.

--- a/action.yml
+++ b/action.yml
@@ -10,68 +10,93 @@ inputs:
     description: "Path to the static website's files (eg frontend/out)"
     required: true
   private-key:
-    description: 'The private key of the Ethereum wallet to use'
+    description: 'The private key of the Ethereum wallet used to sign the deployment'
     required: false
+    default: ''
+  owner-address:
+    description: 'Address of the wallet that owns the website and pays with its credits. Requires an authorization granted to the signing wallet. Leave blank to own and pay with the signing wallet directly'
+    required: false
+    default: ''
+  website-name:
+    description: 'Identifier of the website on your Aleph account. Defaults to the repository name'
+    required: false
+    default: ''
   domain:
     description: 'Domain name to link to the deployed site (eg libertai.io)'
     required: false
     default: ''
   retention_days:
-    description: "Delete files older than this number of days. Leave blank to skip deletion"
+    description: "Delete previous versions of this website older than this number of days. Leave blank to keep all versions"
     required: false
     default: ""
+
 outputs:
   url:
     value: ${{ steps.set-outputs.outputs.url }}
     description: "The deployed URL to access the website"
-
+  cid:
+    value: ${{ steps.set-outputs.outputs.cid }}
+    description: "The IPFS CID (v1) of the deployed files"
+  version:
+    value: ${{ steps.set-outputs.outputs.version }}
+    description: "The version number of the website on Aleph (empty for previews)"
 
 runs:
   using: 'composite'
   steps:
-    - name: Checkout my composite action repo
-      uses: actions/checkout@v6
-      with:
-        repository: aleph-im/web3-hosting-action
-        path: aleph-web3-hosting-action
-
-    - name: Set up Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: 3.11
-
-    - name: Install dependencies
-      run: |
-        pip install -r ./aleph-web3-hosting-action/requirements.txt
+    - name: Select mode
+      id: mode
       shell: bash
-
-    - name: Upload on IPFS
-      shell: bash
+      env:
+        PRIVATE_KEY: ${{ inputs.private-key }}
       run: |
-          result=$(python ./aleph-web3-hosting-action/publish-on-aleph.py ${{ inputs.path }})
-          echo "IPFS_CID_V0=$(echo $result | jq -r '.cid_v0')" >> $GITHUB_ENV
-          echo "IPFS_CID_V1=$(echo $result | jq -r '.cid_v1')" >> $GITHUB_ENV
-
-    - name: Pin with Aleph
-      if: ${{ inputs.private-key != '' }}
-      shell: bash
-      run: |
-        mkdir --parents /home/runner/.aleph-im/private-keys
-        echo ${{ inputs.private-key }} | xxd -r -p > /home/runner/.aleph-im/private-keys/ethereum.key
-
-        pip install 'git+https://github.com/aleph-im/aleph-client@1.9.0'
-        pip install "pycares==4.11.0"
-
-        TMP_JSON=$(mktemp)
-        aleph file pin ${{ env.IPFS_CID_V0 }} > $TMP_JSON 2>/tmp/aleph_err.log
-
-        if [ -s "$TMP_JSON" ]; then
-          ITEM_HASH=$(jq -r '.item_hash' < $TMP_JSON)
-          echo "ITEM_HASH=$ITEM_HASH" >> $GITHUB_ENV
+        if [[ "$GITHUB_EVENT_NAME" == "pull_request" || -z "$PRIVATE_KEY" ]]; then
+          echo "preview=true" >> "$GITHUB_OUTPUT"
+          echo "Mode: preview (free, garbage-collected ~24h after upload)"
         else
-          echo "❌ No output captured from aleph file pin"
+          echo "preview=false" >> "$GITHUB_OUTPUT"
+          echo "Mode: deploy"
+        fi
+
+    - name: Check domain requirements
+      if: ${{ steps.mode.outputs.preview == 'true' && inputs.domain != '' }}
+      shell: bash
+      env:
+        PRIVATE_KEY: ${{ inputs.private-key }}
+        DOMAIN: ${{ inputs.domain }}
+      run: |
+        if [[ -z "$PRIVATE_KEY" ]]; then
+          echo "::error ::You must pass your private key to link a domain."
           exit 1
         fi
+        echo "::notice ::Previews never touch your domain: '$DOMAIN' is only linked when deploying outside of pull requests."
+
+    # ----- Preview flow (pull requests, or no private key) -----
+
+    - name: Set up Python
+      if: ${{ steps.mode.outputs.preview == 'true' }}
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.12'
+
+    - name: Install dependencies
+      if: ${{ steps.mode.outputs.preview == 'true' }}
+      shell: bash
+      run: pip install -r "$GITHUB_ACTION_PATH/requirements.txt"
+
+    - name: Upload preview on IPFS
+      if: ${{ steps.mode.outputs.preview == 'true' }}
+      shell: bash
+      env:
+        SITE_PATH: ${{ inputs.path }}
+      run: |
+        set -euo pipefail
+        CID=$(python "$GITHUB_ACTION_PATH/publish-on-aleph.py" "$SITE_PATH" | jq -r '.cid')
+        if [[ -z "$CID" || "$CID" == "null" ]]; then
+          echo "::error ::No CID returned by the IPFS upload"
+          exit 1
+        fi
+        echo "IPFS_CID=$CID" >> "$GITHUB_ENV"
 
     - name: Find existing PR comment
       if: ${{ github.event_name == 'pull_request' }}
@@ -82,94 +107,219 @@ runs:
         comment-author: 'github-actions[bot]'
         body-includes: Deployed on
 
-    - name: Comment deploy on the PR
-      if: ${{ github.event_name == 'pull_request' && inputs.domain == '' }}
+    - name: Comment the preview link on the PR
+      if: ${{ github.event_name == 'pull_request' }}
       uses: peter-evans/create-or-update-comment@v5
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
         issue-number: ${{ github.event.pull_request.number }}
         body: |
           Deployed on:
-          - https://${{ env.IPFS_CID_V1 }}.ipfs.aleph.sh
+          - https://${{ env.IPFS_CID }}.ipfs.aleph.sh
 
-          ${{ inputs.private-key == '' && '> This link is accessible until the static files are garbage collected, pass your private key to the action to avoid this.' || '' }}
+          > Previews are free and garbage-collected ~24 hours after upload. Re-run the job to refresh the link.
         edit-mode: replace
       continue-on-error: true
 
-    - name: Check if private key is present for linking
-      if: ${{ inputs.domain != '' && inputs.private-key == '' }}
+    # ----- Deploy flow (private key, outside of pull requests) -----
+
+    - name: Install the Aleph CLI
+      if: ${{ steps.mode.outputs.preview == 'false' }}
       shell: bash
       run: |
-        echo "::error ::You must pass your private key to link the domain."
-        exit 1
+        set -euo pipefail
+        ALEPH_CLI_VERSION=0.13.0
+        mkdir -p "$RUNNER_TEMP/aleph-cli"
+        curl -fsSL --retry 3 -o "$RUNNER_TEMP/aleph-cli/aleph" \
+          "https://github.com/aleph-im/aleph-rs/releases/download/v${ALEPH_CLI_VERSION}/aleph-cli-linux-x86_64"
+        chmod +x "$RUNNER_TEMP/aleph-cli/aleph"
+        echo "$RUNNER_TEMP/aleph-cli" >> "$GITHUB_PATH"
+        "$RUNNER_TEMP/aleph-cli/aleph" --version
 
-    - name: Link domain
-      if: ${{ inputs.domain != '' }}
+    - name: Prepare the deployment
+      if: ${{ steps.mode.outputs.preview == 'false' }}
       shell: bash
+      env:
+        ALEPH_PRIVATE_KEY: ${{ inputs.private-key }}
+        INPUT_WEBSITE_NAME: ${{ inputs.website-name }}
+        INPUT_OWNER_ADDRESS: ${{ inputs.owner-address }}
       run: |
-        bash -c "echo 'y' | aleph domain attach '${{ inputs.domain }}' --item-hash $ITEM_HASH"
+        set -euo pipefail
+        export ALEPH_PRIVATE_KEY="${ALEPH_PRIVATE_KEY#0x}"
 
-    - name: Comment domain deploy on the PR
-      if: ${{ inputs.domain != '' && github.event_name == 'pull_request' }}
-      uses: peter-evans/create-or-update-comment@v5
-      with:
-        comment-id: ${{ steps.fc.outputs.comment-id }}
-        issue-number: ${{ github.event.pull_request.number }}
-        body: |
-          Deployed on https://${{ inputs.domain }}
-        edit-mode: replace
-      continue-on-error: true
+        NAME="${INPUT_WEBSITE_NAME:-${GITHUB_REPOSITORY##*/}}"
+        NAME=$(echo "$NAME" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9_-]/-/g')
 
-    - name: Run stale file cleanup
-      if: ${{ inputs.retention_days != '' }}
+        # Resolve the signer address from the private key: --dry-run signs
+        # without submitting anything, and the signed message contains the
+        # sender address (the CID is an arbitrary valid placeholder)
+        SIGNER=$(aleph file pin QmavALnybU8P19w8G1yhxyzWWfP6emKKPKFiaFmjXhKdYE --dry-run --chain eth --json | jq -r '.sender')
+
+        {
+          echo "WEBSITE_NAME=$NAME"
+          echo "SIGNER_ADDRESS=$SIGNER"
+          echo "OWNER_ADDRESS=$INPUT_OWNER_ADDRESS"
+          echo "BILLING_ADDRESS=${INPUT_OWNER_ADDRESS:-$SIGNER}"
+        } >> "$GITHUB_ENV"
+
+        echo "Website: $NAME | Signer: $SIGNER | Owner: ${INPUT_OWNER_ADDRESS:-$SIGNER}"
+
+    - name: Check authorization and credits
+      if: ${{ steps.mode.outputs.preview == 'false' }}
       shell: bash
+      env:
+        ALEPH_PRIVATE_KEY: ${{ inputs.private-key }}
       run: |
-          set -euo pipefail
+        set -euo pipefail
+        export ALEPH_PRIVATE_KEY="${ALEPH_PRIVATE_KEY#0x}"
 
-          STALE_DAYS="${{ inputs.retention_days }}"
-
-          echo "Checking for files older than $STALE_DAYS days..."
-          THRESHOLD=$(date -u -d "-$STALE_DAYS days" +"%Y-%m-%dT%H:%M:%S")
-          echo "Threshold time: $THRESHOLD"
-
-          LIST_OUTPUT=$(mktemp)
-          ERR_LOG=/tmp/aleph_list_err.log
-
-          echo "Fetching Aleph files..."
-          aleph file list --json > "$LIST_OUTPUT" 2>"$ERR_LOG" || true
-
-          if [ ! -s "$LIST_OUTPUT" ]; then
-            echo "❌ No output captured from aleph file list"
-            cat "$ERR_LOG" || true
+        if [[ -n "$OWNER_ADDRESS" ]]; then
+          AUTH_COUNT=$(aleph authorization received --granter "$OWNER_ADDRESS" --chain eth --json | jq 'length')
+          if [[ "$AUTH_COUNT" -eq 0 ]]; then
+            echo "::error ::Wallet $SIGNER_ADDRESS has no authorization from $OWNER_ADDRESS. The owner must run: aleph authorization add $SIGNER_ADDRESS --message-types store,aggregate --aggregate-keys websites,domains --channels ALEPH-CLOUDSOLUTIONS"
             exit 1
           fi
+        fi
 
-          if grep -qE "Failed to retrieve files|Status code" "$LIST_OUTPUT"; then
-            echo "⚠️ Aleph returned an error instead of JSON:"
-            cat "$LIST_OUTPUT"
-            exit 0
+        CREDITS=$(aleph account balance "$BILLING_ADDRESS" --json | jq -r '.credits // 0 | floor')
+        if [[ "$CREDITS" -le 0 ]]; then
+          echo "::error ::$BILLING_ADDRESS has no Aleph credits, the website would be garbage-collected within ~24 hours. Buy credits with 'aleph credit buy' or on the Aleph Cloud console."
+          exit 1
+        fi
+        echo "Billing address $BILLING_ADDRESS holds $CREDITS credits"
+
+    - name: Deploy the website
+      if: ${{ steps.mode.outputs.preview == 'false' }}
+      shell: bash
+      env:
+        ALEPH_PRIVATE_KEY: ${{ inputs.private-key }}
+        SITE_PATH: ${{ inputs.path }}
+      run: |
+        set -euo pipefail
+        export ALEPH_PRIVATE_KEY="${ALEPH_PRIVATE_KEY#0x}"
+        OBO=()
+        [[ -n "$OWNER_ADDRESS" ]] && OBO=(--on-behalf-of "$OWNER_ADDRESS")
+
+        OUT=$(mktemp)
+        if aleph website show "$WEBSITE_NAME" --address "$BILLING_ADDRESS" --json > /dev/null 2>&1; then
+          echo "Updating existing website '$WEBSITE_NAME'..."
+          aleph website update "$WEBSITE_NAME" "$SITE_PATH" --payment-type credit --chain eth --json "${OBO[@]}" > "$OUT"
+        else
+          echo "Deploying new website '$WEBSITE_NAME'..."
+          aleph website deploy "$WEBSITE_NAME" "$SITE_PATH" --payment-type credit --chain eth --json "${OBO[@]}" > "$OUT"
+        fi
+        cat "$OUT"
+
+        {
+          echo "IPFS_CID=$(jq -r '.ipfs_cid' "$OUT")"
+          echo "VOLUME_ID=$(jq -r '.volume_id // .new_volume_id' "$OUT")"
+          echo "WEBSITE_VERSION=$(jq -r '.version' "$OUT")"
+        } >> "$GITHUB_ENV"
+
+    - name: Link the domain
+      if: ${{ steps.mode.outputs.preview == 'false' && inputs.domain != '' }}
+      shell: bash
+      env:
+        ALEPH_PRIVATE_KEY: ${{ inputs.private-key }}
+        DOMAIN: ${{ inputs.domain }}
+      run: |
+        set -euo pipefail
+        export ALEPH_PRIVATE_KEY="${ALEPH_PRIVATE_KEY#0x}"
+        OBO=()
+        [[ -n "$OWNER_ADDRESS" ]] && OBO=(--on-behalf-of "$OWNER_ADDRESS")
+
+        if aleph domain list --address "$BILLING_ADDRESS" --json | jq -e --arg d "$DOMAIN" 'any(.[]; .domain == $d)' > /dev/null; then
+          echo "Re-pointing existing domain $DOMAIN to '$WEBSITE_NAME'..."
+          aleph domain attach "$DOMAIN" --to "$WEBSITE_NAME" --chain eth --json "${OBO[@]}"
+        else
+          echo "Adding new domain $DOMAIN..."
+          aleph domain add "$DOMAIN" --target "$WEBSITE_NAME" --kind ipfs --chain eth --json "${OBO[@]}"
+          echo "::notice ::Domain $DOMAIN linked. If not done yet, configure these DNS records: CNAME $DOMAIN -> ipfs.public.aleph.sh | CNAME _dnslink.$DOMAIN -> _dnslink.$DOMAIN.static.public.aleph.sh | TXT _control.$DOMAIN -> $BILLING_ADDRESS"
+        fi
+
+    - name: Delete versions older than the retention period
+      if: ${{ steps.mode.outputs.preview == 'false' && inputs.retention_days != '' }}
+      shell: bash
+      env:
+        ALEPH_PRIVATE_KEY: ${{ inputs.private-key }}
+        RETENTION_DAYS: ${{ inputs.retention_days }}
+      run: |
+        set -euo pipefail
+        export ALEPH_PRIVATE_KEY="${ALEPH_PRIVATE_KEY#0x}"
+        OBO=()
+        [[ -n "$OWNER_ADDRESS" ]] && OBO=(--on-behalf-of "$OWNER_ADDRESS")
+
+        THRESHOLD=$(( $(date +%s) - RETENTION_DAYS * 86400 ))
+        echo "Deleting versions of '$WEBSITE_NAME' created before $(date -u -d "@$THRESHOLD" +"%Y-%m-%dT%H:%M:%SZ")..."
+
+        HISTORY=$(aleph website show "$WEBSITE_NAME" --address "$BILLING_ADDRESS" --json | jq -r '.history // {} | to_entries[].value')
+        if [[ -z "$HISTORY" ]]; then
+          echo "No previous versions to clean up"
+          exit 0
+        fi
+
+        for VOLUME in $HISTORY; do
+          MSG=$(mktemp)
+          if ! curl -fsSL "https://api2.aleph.im/api/v0/messages/$VOLUME" -o "$MSG"; then
+            echo "⚠️ Could not fetch message $VOLUME, skipping"
+            continue
+          fi
+          STATUS=$(jq -r '.status // empty' "$MSG")
+          CREATED=$(jq -r '.message.time // empty' "$MSG")
+          FILE_CID=$(jq -r '.message.content.item_hash // empty' "$MSG")
+
+          if [[ "$STATUS" != "processed" || -z "$CREATED" || -z "$FILE_CID" ]]; then
+            echo "Skipping $VOLUME (status: ${STATUS:-unknown})"
+            continue
+          fi
+          if [[ "$FILE_CID" == "$IPFS_CID" ]]; then
+            echo "✅ Skipping $VOLUME (same content as the current version)"
+            continue
           fi
 
-          # Loop through files and delete stale ones
-          jq -c '.files[]?' < "$LIST_OUTPUT" | while read -r file; do
-            CREATED=$(echo "$file" | jq -r '.created')
-            ITEM_HASH=$(echo "$file" | jq -r '.item_hash')
+          if (( ${CREATED%.*} < THRESHOLD )); then
+            echo "🗑️ Deleting stale version volume $VOLUME"
+            aleph file delete "$FILE_CID" --reason "web3-hosting-action retention" --yes --chain eth "${OBO[@]}" \
+              || echo "⚠️ Could not delete $FILE_CID (already deleted?)"
+          else
+            echo "✅ Keeping version volume $VOLUME"
+          fi
+        done
 
-            if [[ "$CREATED" < "$THRESHOLD" ]]; then
-              echo "🗑️ Deleting stale file with item_hash: $ITEM_HASH (created: $CREATED)"
-              aleph file forget "$ITEM_HASH" 2>/tmp/aleph_forget_err.log
-            else
-              echo "✅ Skipping fresh file (created: $CREATED)"
-            fi
-          done
+    # ----- Common -----
 
     - name: Set outputs
       id: set-outputs
       shell: bash
+      env:
+        DOMAIN: ${{ inputs.domain }}
+        PREVIEW: ${{ steps.mode.outputs.preview }}
       run: |
-        if [[ -n "${{ inputs.domain }}" ]]; then
-          URL=https://${{ inputs.domain }}
+        set -euo pipefail
+        if [[ -n "$DOMAIN" && "$PREVIEW" == "false" ]]; then
+          URL="https://$DOMAIN"
         else
-          URL=https://${{ env.IPFS_CID_V1 }}.ipfs.aleph.sh
+          URL="https://${IPFS_CID}.ipfs.aleph.sh"
         fi
-        echo "url=$url" >> "$GITHUB_OUTPUT"
+
+        {
+          echo "url=$URL"
+          echo "cid=${IPFS_CID}"
+          echo "version=${WEBSITE_VERSION:-}"
+        } >> "$GITHUB_OUTPUT"
+
+        {
+          echo "### Deployed on Aleph Cloud 🚀"
+          echo ""
+          echo "| | |"
+          echo "|---|---|"
+          echo "| **URL** | $URL |"
+          echo "| **IPFS CID** | \`${IPFS_CID}\` |"
+          if [[ -n "${WEBSITE_VERSION:-}" ]]; then
+            echo "| **Version** | ${WEBSITE_VERSION} |"
+          fi
+          if [[ "$PREVIEW" == "true" ]]; then
+            echo ""
+            echo "> Preview, garbage-collected ~24 hours after upload."
+          fi
+        } >> "$GITHUB_STEP_SUMMARY"

--- a/publish-on-aleph.py
+++ b/publish-on-aleph.py
@@ -1,40 +1,57 @@
 #!/usr/bin/env python3
-import requests
+"""Upload a directory to the Aleph IPFS gateway without authentication.
+
+Used for free previews: the content isn't pinned by any STORE message,
+so the gateway garbage-collects it ~24 hours after upload and no
+credits are consumed. Production deployments don't use this script,
+they go through the Aleph CLI instead (see action.yml).
+"""
 import json
 import sys
 from pathlib import Path
-from cid import make_cid
 
-def upload_with_requests(folder: Path, gateway: str):
+import requests
+
+IPFS_GATEWAY = "https://ipfs.aleph.cloud"
+
+
+def upload_directory(folder: Path, gateway: str) -> str:
     url = f"{gateway}/api/v0/add"
+    # cid-version=1 returns a base32 CID directly, as required for the
+    # case-insensitive subdomain gateway URLs (https://<cid>.ipfs.aleph.sh).
+    # raw-leaves matches the Aleph CLI upload defaults so a preview and a
+    # deployment of the same content produce the same CID.
     params = {
         "recursive": "true",
-        "wrap-with-directory": "true"
+        "wrap-with-directory": "true",
+        "cid-version": "1",
+        "raw-leaves": "true",
     }
 
-    # Prepare file data like curl -F file=@./dist/
+    # The filename of each part must be the path relative to the uploaded
+    # folder, or the gateway can't rebuild the directory tree / infer MIME
+    # types and serves everything as text/plain.
     files = []
-    for path in folder.rglob("*"):
+    for path in sorted(folder.rglob("*")):
         if path.is_file():
             relative_path = path.relative_to(folder)
-            files.append(
-                ("file", (str(relative_path), open(path, "rb")))
-            )
+            files.append(("file", (str(relative_path), open(path, "rb"))))
 
-    response = requests.post(url, params=params, files=files)
+    if not files:
+        raise RuntimeError(f"No files found in {folder}")
+
+    response = requests.post(url, params=params, files=files, timeout=1200)
     response.raise_for_status()
 
-    # Parse the response line-by-line
-    cid_v0 = None
-    for line in response.text.strip().splitlines():
-        entry = json.loads(line)
-        cid_v0 = entry.get("Hash")
+    # The response streams one JSON line per file; the wrapper directory
+    # containing the whole site is the last entry.
+    lines = response.text.strip().splitlines()
+    cid = json.loads(lines[-1]).get("Hash") if lines else None
 
-    if not cid_v0:
+    if not cid:
         raise RuntimeError("CID not found in response.")
+    return cid
 
-    cid_v1 = make_cid(cid_v0).to_v1().encode("base32").decode()
-    return {"cid_v0": cid_v0, "cid_v1": cid_v1}
 
 if __name__ == "__main__":
     path = Path(sys.argv[1])
@@ -42,5 +59,5 @@ if __name__ == "__main__":
         print("Error: path must be a directory")
         sys.exit(1)
 
-    result = upload_with_requests(path.resolve(), "https://ipfs-2.aleph.im")
-    print(json.dumps(result))
+    cid = upload_directory(path.resolve(), IPFS_GATEWAY)
+    print(json.dumps({"cid": cid}))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,1 @@
 requests==2.32.4
-py-cid @ git+https://github.com/ipld/py-cid.git@b13b51774ac3309c3c28a8da6eeab6d1e75dcddc


### PR DESCRIPTION
Major rewrite of the action, proven in production (this code deploys and serves https://libertai.io from Aleph Cloud via tag `v2.0.0-rc1`).

## Highlights
- **Rust Aleph CLI** (pinned 0.13.0) replaces the Python `aleph-client` — no runtime pip installs / key-file juggling.
- **Credits payment** (`--payment-type credit`).
- **Delegated deployments** via new `owner-address` input: one owner wallet holds credits + owns all sites, low-privilege per-repo CI keys only sign on its behalf. Fails fast if authorization or credits are missing.
- **Websites with version history** under `website-name` (defaults to repo name); domains auto-repointed on update.
- **Free PR previews** unchanged (anonymous, GC'd ~24h).
- **Per-website retention**: `retention_days` only deletes this site's previous versions.
- New `cid` / `version` outputs; fixed empty `url` output.
- Dropped the runtime self-checkout (uses `GITHUB_ACTION_PATH`) and the `py-cid` dependency.

## ⚠️ Breaking for existing v1 users
v1.x's `action.yml` checks out the **default branch (main)** at runtime to fetch `publish-on-aleph.py`. Merging this changes that script's output format, so **all v1.x users break once this lands on main** — even those pinned to a specific `@v1.1.x` tag. This is the intended clean-cut to v2.

## Release plan
After merge: tag `v2.0.0` + floating `v2` from `main`, create the release.