### PR TITLE
feat: support cleanup-only mode on pull_request closed events

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ To keep credits low, the action keeps only the latest build per pull request, an
 ```yml
 on:
   pull_request:
+    # Add `closed` to tear a preview down the moment its PR is closed or merged.
+    # Without it, closed previews are still reaped, but only on the next pull
+    # request event (see "Preview cleanup" below).
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   deploy-previews:
@@ -105,6 +109,13 @@ jobs:
 ```
 
 > The `pull-requests: write` permission is required so the action can comment the preview link and detect closed PRs to clean up their previews.
+
+#### Preview cleanup
+
+On every pull request event the action first reaps the previews of any pull requests that are now closed, then deploys the current one. So previews are always cleaned up, but the timing depends on your trigger:
+
+- **Without `closed`** in `types` (the default `pull_request` trigger): a closed PR's preview is removed on the next pull request event from any PR. Simple, but a preview can linger if the repository goes quiet.
+- **With `closed`** in `types`: the action runs in cleanup-only mode for that event - it tears the preview down immediately and skips the deploy and comment steps (so it never recreates the preview it just removed). This run does not require credits on the billing wallet.
 
 ### Remove older versions
 

--- a/action.yml
+++ b/action.yml
@@ -59,9 +59,19 @@ runs:
         fi
         if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
           echo "preview=true" >> "$GITHUB_OUTPUT"
-          echo "Mode: preview (pull request #${{ github.event.pull_request.number }})"
+          # On a `closed` event (PR closed or merged) we only tear the preview
+          # down - never redeploy it. This lets a workflow add `closed` to its
+          # trigger types for instant teardown without recreating the preview.
+          if [[ "${{ github.event.action }}" == "closed" ]]; then
+            echo "cleanup_only=true" >> "$GITHUB_OUTPUT"
+            echo "Mode: preview cleanup (pull request #${{ github.event.pull_request.number }} closed)"
+          else
+            echo "cleanup_only=false" >> "$GITHUB_OUTPUT"
+            echo "Mode: preview (pull request #${{ github.event.pull_request.number }})"
+          fi
         else
           echo "preview=false" >> "$GITHUB_OUTPUT"
+          echo "cleanup_only=false" >> "$GITHUB_OUTPUT"
           echo "Mode: deploy"
         fi
 
@@ -117,6 +127,7 @@ runs:
       shell: bash
       env:
         ALEPH_PRIVATE_KEY: ${{ inputs.private-key }}
+        CLEANUP_ONLY: ${{ steps.mode.outputs.cleanup_only }}
       run: |
         set -euo pipefail
         export ALEPH_PRIVATE_KEY="${ALEPH_PRIVATE_KEY#0x}"
@@ -127,6 +138,13 @@ runs:
             echo "::error ::Wallet $SIGNER_ADDRESS has no authorization from $OWNER_ADDRESS. The owner must run: aleph authorization add $SIGNER_ADDRESS --message-types store,aggregate --aggregate-keys websites,domains --channels ALEPH-CLOUDSOLUTIONS"
             exit 1
           fi
+        fi
+
+        # Tearing a preview down does not cost credits, and you may be cleaning
+        # up precisely because the wallet ran dry - so skip the credit check.
+        if [[ "$CLEANUP_ONLY" == "true" ]]; then
+          echo "Cleanup-only run: skipping the credit check"
+          exit 0
         fi
 
         CREDITS=$(aleph account balance "$BILLING_ADDRESS" --json | jq -r '.credits // 0 | floor')
@@ -152,8 +170,11 @@ runs:
 
         # List this repository's preview websites and drop the ones whose
         # pull request is closed, releasing their file pins so they stop
-        # consuming credits. Done here (not on a `closed` trigger) so the
-        # action stays a single step of the normal build workflow.
+        # consuming credits. This runs on every pull request event, so closed
+        # previews are reaped by later PR activity even without a `closed`
+        # trigger; adding `closed` to the workflow's trigger types makes the
+        # teardown happen immediately (this step still runs, the deploy steps
+        # below are skipped).
         SITES=$(aleph website list --address "$BILLING_ADDRESS" --json \
           | jq -r --arg b "$WEBSITE_BASE" '.[] | select(.name | test("^" + $b + "-preview-pr-[0-9]+$")) | .name')
 
@@ -177,7 +198,7 @@ runs:
         done
 
     - name: Deploy the preview
-      if: ${{ steps.mode.outputs.preview == 'true' }}
+      if: ${{ steps.mode.outputs.preview == 'true' && steps.mode.outputs.cleanup_only != 'true' }}
       shell: bash
       env:
         ALEPH_PRIVATE_KEY: ${{ inputs.private-key }}
@@ -213,7 +234,7 @@ runs:
         fi
 
     - name: Find existing PR comment
-      if: ${{ steps.mode.outputs.preview == 'true' }}
+      if: ${{ steps.mode.outputs.preview == 'true' && steps.mode.outputs.cleanup_only != 'true' }}
       uses: peter-evans/find-comment@v4
       id: fc
       with:
@@ -222,7 +243,7 @@ runs:
         body-includes: Deployed on
 
     - name: Comment the preview link on the PR
-      if: ${{ steps.mode.outputs.preview == 'true' }}
+      if: ${{ steps.mode.outputs.preview == 'true' && steps.mode.outputs.cleanup_only != 'true' }}
       uses: peter-evans/create-or-update-comment@v5
       with:
         comment-id: ${{ steps.fc.outputs.comment-id }}
@@ -334,6 +355,8 @@ runs:
 
     - name: Set outputs
       id: set-outputs
+      # Nothing is deployed on a cleanup-only run, so there are no outputs to set.
+      if: ${{ steps.mode.outputs.cleanup_only != 'true' }}
       shell: bash
       env:
         DOMAIN: ${{ inputs.domain }}


### PR DESCRIPTION
## Summary

Lets a consuming workflow add `closed` to its `pull_request` trigger types to tear a PR's preview down the moment the PR is closed or merged, instead of waiting for the next pull request event.

## Why

On every `pull_request` event the action runs the closed-PR cleanup sweep and then the deploy step. So today, if a workflow adds `closed` to its trigger types, the action reaps the just-closed PR's preview and then immediately redeploys it in the same run, leaving it in place. That is why the docs tell users not to add `closed`. Cleanup therefore only happens opportunistically, on the next PR activity from any PR, which can leave previews (and their credit cost) lingering on a quiet repository.

## What changed

`action.yml`:
- The mode step sets a new `cleanup_only` output, `true` when `github.event.action == 'closed'` on a `pull_request` event.
- `Deploy the preview`, `Find existing PR comment`, `Comment the preview link on the PR`, and `Set outputs` skip when `cleanup_only` is set. Only the cleanup sweep runs, which reaps the just-closed preview. (`Set outputs` would otherwise fail under `set -u` on a cleanup run, since `IPFS_CID` is never set.)
- The credit check is skipped on cleanup-only runs: teardown costs nothing, and you may be cleaning up precisely because the wallet ran dry. The authorization check still runs.

`README.md`:
- The Deploy previews example uses `types: [opened, synchronize, reopened, closed]`.
- A new "Preview cleanup" subsection explains the timing with and without the `closed` trigger.

## Compatibility

Fully backward compatible. Workflows that do not list `closed` in their trigger types are unaffected: `cleanup_only` is always `false` for them and every step behaves exactly as before.

## Test plan

The action has no test harness (just `action.yml` + `README.md`). Verified by:
- `action.yml` parses as valid YAML.
- Manual trace of all step guards across `pull_request` opened/synchronize/reopened (deploy + sweep), `pull_request` closed (sweep only, no redeploy, no credit check, no outputs), and non-PR push (production deploy) events.

Once released (re-pointing `v2` or cutting a new tag), the `aleph-cloud-docs` PR-preview workflow will add `closed` to its trigger to get immediate teardown.
